### PR TITLE
replace the use of (\!\!) with new function (@@) in all the chili/Dom…

### DIFF
--- a/Chili/Patch.hs
+++ b/Chili/Patch.hs
@@ -17,7 +17,7 @@ import Data.Text (unpack)
 import qualified Data.Text as Text
 import Chili.Diff (Patch(..), diff)
 import Chili.Internal (debugStrLn, debugPrint)
-import Chili.Types (Control(..), EventName(..), Html(..), Attr(..), JSDocument, JSElement(..), JSNode, Loop, VDOMEvent(..), WithModel, addEventListener, childNodes, createJSElement, createJSTextNode, item, js_setTimeout, eventName, getFirstChild, getLength, replaceData, setAttribute, setProperty, unJSNode, setValue, parentNode, removeChild, replaceChild, toJSNode, appendChild, descendants, nodeType, currentDocument, newEvent, dispatchEvent)
+import Chili.Types ((@@), Control(..), EventName(..), Html(..), Attr(..), JSDocument, JSElement(..), JSNode, Loop, PatchIndexTooLarge(..), VDOMEvent(..), WithModel, addEventListener, childNodes, createJSElement, createJSTextNode, item, js_setTimeout, eventName, getFirstChild, getLength, replaceData, setAttribute, setProperty, unJSNode, setValue, parentNode, removeChild, replaceChild, toJSNode, appendChild, descendants, nodeType, currentDocument, newEvent, dispatchEvent)
 import Chili.TDVar (TDVar, readTDVar, cleanTDVar, isDirtyTDVar)
 import GHCJS.Foreign.Callback (OnBlocked(..), Callback, asyncCallback, asyncCallback1, syncCallback1)
 
@@ -228,6 +228,7 @@ We return an assoc list of the (indices, node)
 
 -- FIXME: do not walk down DOM trees that contain no nodes if interest
 -}
+
 getNodes :: JSNode      -- ^ root node of DOM
          -> Html model -- ^ virtual DOM that matches the current DOM
          -> [Int]       -- ^ nodes indices we want (using in-order numbering)
@@ -286,7 +287,7 @@ getNodes currNode vdom nodeIndices = do
                       childNodes' <- mapM (\i' -> do (Just c) <- item cs (fromIntegral i')
                                                      liftIO $ debugStrLn $ "l = " ++ show l ++ ", length children = " ++ show (length children) ++ ", i' = " ++ show i'
                                                      inc
-                                                     getNodes' c (children!!i') is'
+                                                     getNodes' c (children @@ i') is'
                                           ) [0..(l-1)]
                       if (i == index)
                       then do return $ (i, currNode) : (concat childNodes')

--- a/Dominator/Patch.hs
+++ b/Dominator/Patch.hs
@@ -9,7 +9,7 @@ import Control.Monad (when)
 import Control.Monad.State (StateT, evalStateT, get, put)
 import Control.Monad.Trans (MonadIO(..))
 import Chili.Debug (Debug)
-import Chili.Types (JSDocument, JSElement(..), JSNode, JSNodeList, unJSNode, addEventListener, addEventListenerOpt, currentDocument, childNodes, deleteProperty, eventName, getFirstChild, getLength, item, parentNode, nodeType, item, toJSNode, removeAttribute, removeChild, replaceData, replaceChild, setAttribute, setProperty, insertBefore)
+import Chili.Types ((@@), JSDocument, JSElement(..), JSNode, JSNodeList, PatchIndexTooLarge(..), unJSNode, addEventListener, addEventListenerOpt, currentDocument, childNodes, deleteProperty, eventName, getFirstChild, getLength, item, parentNode, nodeType, item, toJSNode, removeAttribute, removeChild, replaceData, replaceChild, setAttribute, setProperty, insertBefore)
 import Data.List (sort)
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -251,7 +251,7 @@ getNodes currNode vdom nodeIndices = do
                       childNodes' <- mapM (\i' -> do (Just c) <- item cs (fromIntegral i')
                                                      liftIO $ debugStrLn $ "l = " ++ show l ++ ", length children = " ++ show (length children) ++ ", i' = " ++ show i'
                                                      inc
-                                                     getNodes' c (children!!i') is'
+                                                     getNodes' c (children@@i') is'
                                           ) [0..(l-1)]
                       if (i == index)
                       then do return $ (i, currNode) : (concat childNodes')

--- a/Dominator/PatchPartial.hs
+++ b/Dominator/PatchPartial.hs
@@ -9,7 +9,7 @@ import Control.Monad (when)
 import Control.Monad.State (StateT, evalStateT, get, put)
 import Control.Monad.Trans (MonadIO(..))
 import Chili.Debug (Debug)
-import Chili.Types (JSDocument, JSElement(..), JSNode, JSNodeList, unJSNode, addEventListener, addEventListenerOpt, currentDocument, childNodes, deleteProperty, eventName, getFirstChild, getLength, item, parentNode, nodeType, item, toJSNode, removeAttribute, removeChild, replaceData, replaceChild, setAttribute, setProperty, insertBefore)
+import Chili.Types ((@@), JSDocument, JSElement(..), JSNode, JSNodeList, PatchIndexTooLarge(..), unJSNode, addEventListener, addEventListenerOpt, currentDocument, childNodes, deleteProperty, eventName, getFirstChild, getLength, item, parentNode, nodeType, item, toJSNode, removeAttribute, removeChild, replaceData, replaceChild, setAttribute, setProperty, insertBefore)
 import Data.List (sort)
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -304,7 +304,7 @@ getNodes isProtected currNode vdom nodeIndices = do
                                                      liftIO $ debugStrLn $ "l = " ++ show l ++ ", length children = " ++ show (length children) ++ ", i' = " ++ show i'
                                                      inc
 
-                                                     getNodes' c (children!!i') is'
+                                                     getNodes' c (children@@i') is'
                                           ) [0..(l-1)]
                       if (i == index)
                       then do return $ (i, currNode) : (concat childNodes')

--- a/chili.cabal
+++ b/chili.cabal
@@ -23,6 +23,7 @@ library
                        ghcjs-base,
                        lens,
                        mtl,
+                       safe,
                        stm,
                        template-haskell,
                        text


### PR DESCRIPTION
…inator diff/patch instances. @@ is implemented with Safe.atMay, and throws custom exception PatchIndexTooLarge if the index is too large.